### PR TITLE
Fix get method to catch empty params object

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -252,11 +252,7 @@ var Service = function () {
 
             var _self = this;
 
-            if (typeof params === 'undefined') {
-                params = { query: {} };
-            }
-
-            params = Object.assign({}, params, { $limit: 1, $skip: 0 });
+            params = Object.assign({ query: {} }, params, { $limit: 1, $skip: 0 });
             params.query[_self.options.idfield] = id;
 
             return new Promise(function (resolve, reject) {

--- a/src/index.js
+++ b/src/index.js
@@ -220,11 +220,7 @@ class Service {
 	get(id, params) {
 		let _self = this;
 
-        if (typeof params === 'undefined') {
-            params = {query:{}};
-        }
-
-        params = Object.assign({}, params, {$limit:1,$skip:0});
+        params = Object.assign({query:{}}, params, {$limit:1,$skip:0});
         params.query[_self.options.idfield] = id;
 
 		return new Promise((resolve, reject) => {


### PR DESCRIPTION
This fixes the case when an empty object is passed as `params`

The original `params === undefined` didn't cover this because an empty object is not undefined and thus the adapter fails because `query:{}` is missing.