### PR TITLE
Fix typescript definition for SolrServiceOptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -205,6 +205,29 @@
       "integrity": "sha512-onlIwbaeqvZyniGPfdw/TEhKIh79pz66L1q06WUQqJLnAb6wbjvOtepLYTGHTqzdXgBYIE3ZdmqHDGsRsbBz7A==",
       "dev": true
     },
+    "@types/node-fetch": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
+      "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "@types/parsimmon": {
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/@types/parsimmon/-/parsimmon-1.10.2.tgz",

--- a/package.json
+++ b/package.json
@@ -64,13 +64,14 @@
     "@feathersjs/adapter-tests": "^4.5.2",
     "@feathersjs/express": "^4.5.8",
     "@feathersjs/feathers": "^4.5.8",
+    "@types/node-fetch": "^2.5.7",
     "dtslint": "^4.0.0",
     "istanbul": "^1.1.0-alpha.1",
+    "minimist": ">=1.2.5",
     "mocha": "^8.1.3",
     "node-fetch": "^2.6.0",
     "semistandard": "^14.2.3",
     "tslint": "^6.1.3",
-    "undici": "^1.3.1",
-    "minimist": ">=1.2.5"
+    "undici": "^1.3.1"
   }
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,11 +1,18 @@
 // TypeScript Version: 3.0
 import { Params, Paginated, Id, NullableId } from '@feathersjs/feathers';
 import { AdapterService, ServiceOptions, InternalServiceMethods } from '@feathersjs/adapter-commons';
+import fetch from 'node-fetch';
+declare function undici(url: any, opts: object): any;
+
+export class FetchClient { }
+export class UndiciClient { }
 
 export interface solrService {
   [key: number]: any;
 }
 
+export declare function SolrClient(fn: typeof undici, host: string, opts: object): UndiciClient;
+export declare function SolrClient(fn: typeof fetch, host: string): FetchClient;
 export interface SolrServiceOptions extends ServiceOptions {
   store: solrService;
   startId: number;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,3 @@
-// TypeScript Version: 3.0
 import { Params, Paginated, Id, NullableId } from '@feathersjs/feathers';
 import { AdapterService, ServiceOptions, InternalServiceMethods } from '@feathersjs/adapter-commons';
 import fetch from 'node-fetch';
@@ -18,6 +17,7 @@ export interface SolrServiceOptions extends ServiceOptions {
   startId: number;
   matcher?: (query: any) => any;
   sorter?: (sort: any) => any;
+  Model: FetchClient | UndiciClient;
 }
 
 export class Service<T = any> extends AdapterService<T> implements InternalServiceMethods<T> {


### PR DESCRIPTION
When using feathers-solr in a typescript project we will get an error when defining the Model in the SolrServiceOptions, because it is not defined.

This PR will add the Model in the SolrServiceOptions definition.
It also adds basic definitions for
- SolrClient
- FetchClient
- UndiciClient

This should help checking that only an allowed http client is used for the communication wit Solr.